### PR TITLE
Explicitly list eventlogging library requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,9 @@ setup(
         'Programming Language :: Python :: 3',
     ],
     install_requires=[
+        'jsonschema',
+        'python-json-logger',
+        'traitlets',
         'notebook',
     ],
 )


### PR DESCRIPTION
All are pure python libraries with minimal other dependencies.

We should probably remove 'notebook' from here, and move
it to its own jupyter_telemetry_serverextension package.