### PR TITLE
Pass a list of logging handlers to the event log

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-[![circleci](https://circleci.com/gh/jupyter/telemetry?style=shield)][https://circleci.com/gh/jupyter/telemetry]
+[![circleci](https://circleci.com/gh/jupyter/telemetry?style=shield)](https://circleci.com/gh/jupyter/telemetry)
 [![codecov](https://codecov.io/gh/jupyter/telemetry/branch/master/graph/badge.svg)](https://codecov.io/gh/jupyter/telemetry)
 
 Telemetry for Jupyter Applications and extensions.

--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -1,16 +1,15 @@
 """
 Emit structured, discrete events when various actions happen.
 """
-from traitlets.config import Configurable
-
 import logging
-from datetime import datetime
-import jsonschema
-from pythonjsonlogger import jsonlogger
-from traitlets import List 
-from ruamel.yaml import YAML
 import json
+import jsonschema
+from datetime import datetime
+from pythonjsonlogger import jsonlogger
+from ruamel.yaml import YAML
 
+from traitlets import List 
+from traitlets.config import Configurable
 
 from .traits import HandlersList
 
@@ -110,7 +109,7 @@ class EventLog(Configurable):
         """
         Record given event with schema has occured.
         """
-        if not (self.handlers_maker and schema_name in self.allowed_schemas):
+        if not (self.handlers_list and schema_name in self.allowed_schemas):
             # if handler isn't set up or schema is not explicitly whitelisted,
             # don't do anything
             return

--- a/jupyter_telemetry/traits.py
+++ b/jupyter_telemetry/traits.py
@@ -11,8 +11,10 @@ class HandlersList(TraitType):
 
     def validate_elements(self, obj, value):
         if len(value) > 0:
-            if isinstance(value[0], logging.Handler) is False:
-                self.element_error(obj)
+            # Check that all elements are logging handlers.
+            for el in value:
+                if isinstance(el, logging.Handler) is False:
+                    self.element_error(obj)
 
     def element_error(self, obj):
         raise TraitError(

--- a/jupyter_telemetry/traits.py
+++ b/jupyter_telemetry/traits.py
@@ -31,10 +31,6 @@ class HandlersList(TraitType):
             return handlers_list
         # If already a callable, check that a list is returned.
         elif callable(value):
-            out = value()
-            if type(out) != list:
-                self.error(obj, value)
-            self.validate_elements(obj, out)
             return value
         else:
             self.error(obj, value)

--- a/jupyter_telemetry/traits.py
+++ b/jupyter_telemetry/traits.py
@@ -31,7 +31,6 @@ class HandlersList(TraitType):
             def handlers_list(): 
                 return value
             return handlers_list
-        # If already a callable, check that a list is returned.
         elif callable(value):
             return value
         else:

--- a/tests/test_register_schema.py
+++ b/tests/test_register_schema.py
@@ -73,7 +73,7 @@ def test_record_event():
 
     output = io.StringIO()
     handler = logging.StreamHandler(output)
-    el = EventLog(handlers_maker=lambda el: [handler])
+    el = EventLog(handlers_list=[handler])
     el.register_schema(schema)
     el.allowed_schemas = ['test/test']
 
@@ -136,7 +136,7 @@ def test_allowed_schemas():
 
     output = io.StringIO()
     handler = logging.StreamHandler(output)
-    el = EventLog(handlers_maker=lambda el: [handler])
+    el = EventLog(handlers_list=[handler])
     # Just register schema, but do not mark it as allowed
     el.register_schema(schema)
 
@@ -165,7 +165,7 @@ def test_record_event_badschema():
         }
     }
 
-    el = EventLog(handlers_maker=lambda el: [logging.NullHandler()])
+    el = EventLog(handlers_list=[logging.NullHandler()])
     el.register_schema(schema)
     el.allowed_schemas = ['test/test']
 

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -4,7 +4,7 @@ from traitlets import HasTraits, TraitError
 from jupyter_telemetry.traits import HandlersList
 
 
-class HasHandlerList(HasTraits):
+class HasHandlersList(HasTraits):
     handlers_list = HandlersList(
         None,
         allow_none=True
@@ -16,7 +16,7 @@ def test_good_handlers_list_value():
         logging.NullHandler(), 
         logging.NullHandler()
     ]
-    obj = HasHandlerList(
+    obj = HasHandlersList(
         handlers_list=handlers
     )
     assert obj.handlers_list
@@ -25,7 +25,7 @@ def test_bad_handlers_list_values():
     handlers = [0, 1]
     
     with pytest.raises(TraitError):
-        obj = HasHandlerList(
+        obj = HasHandlersList(
             handlers_list=handlers
         )
 
@@ -35,6 +35,6 @@ def test_mixed_handlers_list_values():
         1
     ]
     with pytest.raises(TraitError):
-        obj = HasHandlerList(
+        obj = HasHandlersList(
             handlers_list=handlers
         )

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -19,7 +19,7 @@ def test_good_handlers_list_value():
     obj = HasHandlersList(
         handlers_list=handlers
     )
-    assert obj.handlers_list
+    assert obj.handlers_list() == handlers
 
 def test_bad_handlers_list_values():
     handlers = [0, 1]

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -1,44 +1,40 @@
 import pytest
-
 import logging 
-
-from traitlets import HasTraits
-from traitlets.tests.test_traitlets import TraitTestBase
+from traitlets import HasTraits, TraitError
 from jupyter_telemetry.traits import HandlersList
 
 
-class HandlersListTrait(HasTraits):
-    
-    value = HandlersList(
+class HasHandlerList(HasTraits):
+    handlers_list = HandlersList(
         None,
         allow_none=True
     )
 
 
-class TestHandlersList(TraitTestBase):
-
-    obj = HandlersListTrait()
-
-    _default_value = None
-    _good_values = [
-        [logging.NullHandler(), logging.NullHandler()]
+def test_good_handlers_list_value():
+    handlers = [
+        logging.NullHandler(), 
+        logging.NullHandler()
     ]
-    _bad_values = [
-        [0, 1],
-        ['a', 'b'],
-        [logging.NullHandler(), 0]
+    obj = HasHandlerList(
+        handlers_list=handlers
+    )
+    assert obj.handlers_list
+
+def test_bad_handlers_list_values():
+    handlers = [0, 1]
+    
+    with pytest.raises(TraitError):
+        obj = HasHandlerList(
+            handlers_list=handlers
+        )
+
+def test_mixed_handlers_list_values():
+    handlers = [
+        logging.NullHandler(), 
+        1
     ]
-
-    def assertEqual(self, a, b):
-        # Hijack assertEquals method to check for comparison between two callables
-        if callable(a) and callable(b):
-            pass
-        else:
-            super(TestHandlersList, self).assertEqual(a, b)
-
-    def coerce(self, value):
-        # Coerce value when comparing the trait's value to
-        # the given value.
-        def handlers_list():
-            return value
-        return handlers_list
+    with pytest.raises(TraitError):
+        obj = HasHandlerList(
+            handlers_list=handlers
+        )

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -1,0 +1,44 @@
+import pytest
+
+import logging 
+
+from traitlets import HasTraits
+from traitlets.tests.test_traitlets import TraitTestBase
+from jupyter_telemetry.traits import HandlersList
+
+
+class HandlersListTrait(HasTraits):
+    
+    value = HandlersList(
+        None,
+        allow_none=True
+    )
+
+
+class TestHandlersList(TraitTestBase):
+
+    obj = HandlersListTrait()
+
+    _default_value = None
+    _good_values = [
+        [logging.NullHandler(), logging.NullHandler()]
+    ]
+    _bad_values = [
+        [0, 1],
+        ['a', 'b'],
+        [logging.NullHandler(), 0]
+    ]
+
+    def assertEqual(self, a, b):
+        # Hijack assertEquals method to check for comparison between two callables
+        if callable(a) and callable(b):
+            pass
+        else:
+            super(TestHandlersList, self).assertEqual(a, b)
+
+    def coerce(self, value):
+        # Coerce value when comparing the trait's value to
+        # the given value.
+        def handlers_list():
+            return value
+        return handlers_list


### PR DESCRIPTION
Here, I'm exploring a way around traitlet's constraint that only allows pickleable traits. Right now, this constraint forces end-users to list handlers by *passing a callable object that returns a list of handlers*. 

By exploiting traitlet's `validate` method, I can create a trait that turns a user-defined list into a callable under the hood, avoid traitlet's pickleable constrait at instantiation, and take this burden off of the end-user. 

This is certaintly a hack. If we don't think this approach is valid, I'm totally fine with abandoning it! 😄 