### PR TITLE
solve handlers list traitlets issue!

### DIFF
--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -11,7 +11,7 @@ from ruamel.yaml import YAML
 from traitlets import List 
 from traitlets.config import Configurable, Config
 
-from .traits import HandlersList
+from .traits import Handlers
 
 yaml = YAML(typ='safe')
 
@@ -30,7 +30,7 @@ class EventLog(Configurable):
     """
     Send structured events to a logging sink
     """
-    handlers = HandlersList(
+    handlers = Handlers(
         [],
         config=True,
         allow_none=True,

--- a/jupyter_telemetry/traits.py
+++ b/jupyter_telemetry/traits.py
@@ -2,7 +2,7 @@ import logging
 from traitlets import TraitType, TraitError, validate
 
 
-class HandlersList(TraitType):
+class Handlers(TraitType):
     """A trait that takes a list of logging handlers and converts
     it to a callable that returns that list (thus, making this
     trait pickleable). 

--- a/jupyter_telemetry/traits.py
+++ b/jupyter_telemetry/traits.py
@@ -24,14 +24,18 @@ class HandlersList(TraitType):
         )
 
     def validate(self, obj, value):
-        # If given a list, convert to callable that returns the list.
-        if type(value) == list:
+        # If given a callable, call it and set the
+        # value of this trait to the returned list. 
+        # Verify that the callable returns a list
+        # of logging handler instances.
+        if callable(value):
+            out = value()
+            self.validate_elements(obj, out)
+            return out
+        # If a list, check it's elements to verify
+        # that each element is a logging handler instance.
+        elif type(value) == list:
             self.validate_elements(obj, value)
-            # Wrap list with callable
-            def handlers_list(): 
-                return value
-            return handlers_list
-        elif callable(value):
             return value
         else:
             self.error(obj, value)

--- a/tests/test_eventlog.py
+++ b/tests/test_eventlog.py
@@ -1,0 +1,52 @@
+import pytest
+import logging
+from traitlets.config.loader import PyFileConfigLoader
+from traitlets import TraitError
+
+from jupyter_telemetry.eventlog import EventLog
+
+GOOD_CONFIG = """
+import logging
+
+c.EventLog.handlers = [
+    logging.StreamHandler()
+]
+"""
+
+BAD_CONFIG = """
+import logging
+
+c.EventLog.handlers = [
+    0
+]
+"""
+
+def get_config_from_file(path, content):
+    # Write config file
+    filename = 'config.py'
+    config_file = path / filename
+    config_file.write_text(content)    
+
+    # Load written file.
+    loader = PyFileConfigLoader(filename, path=str(path))
+    cfg = loader.load_config()
+    return cfg
+
+def test_good_config_file(tmp_path):
+    cfg = get_config_from_file(tmp_path, GOOD_CONFIG)
+
+    # Pass config to EventLog
+    e = EventLog(config=cfg)
+
+    # Assert the 
+    assert len(e.handlers) > 0
+    assert isinstance(e.handlers[0], logging.Handler)
+
+
+def test_bad_config_file(tmp_path):
+    cfg = get_config_from_file(tmp_path, BAD_CONFIG)
+
+    with pytest.raises(TraitError):
+        e = EventLog(config=cfg)
+
+

--- a/tests/test_register_schema.py
+++ b/tests/test_register_schema.py
@@ -73,7 +73,7 @@ def test_record_event():
 
     output = io.StringIO()
     handler = logging.StreamHandler(output)
-    el = EventLog(handlers_list=[handler])
+    el = EventLog(handlers=[handler])
     el.register_schema(schema)
     el.allowed_schemas = ['test/test']
 
@@ -136,7 +136,7 @@ def test_allowed_schemas():
 
     output = io.StringIO()
     handler = logging.StreamHandler(output)
-    el = EventLog(handlers_list=[handler])
+    el = EventLog(handlers=[handler])
     # Just register schema, but do not mark it as allowed
     el.register_schema(schema)
 
@@ -165,7 +165,7 @@ def test_record_event_badschema():
         }
     }
 
-    el = EventLog(handlers_list=[logging.NullHandler()])
+    el = EventLog(handlers=[logging.NullHandler()])
     el.register_schema(schema)
     el.allowed_schemas = ['test/test']
 

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -5,7 +5,7 @@ from jupyter_telemetry.traits import HandlersList
 
 
 class HasHandlersList(HasTraits):
-    handlers_list = HandlersList(
+    handlers = HandlersList(
         None,
         allow_none=True
     )
@@ -17,16 +17,16 @@ def test_good_handlers_list_value():
         logging.NullHandler()
     ]
     obj = HasHandlersList(
-        handlers_list=handlers
+        handlers=handlers
     )
-    assert obj.handlers_list() == handlers
+    assert obj.handlers == handlers
 
 def test_bad_handlers_list_values():
     handlers = [0, 1]
     
     with pytest.raises(TraitError):
         obj = HasHandlersList(
-            handlers_list=handlers
+            handlers=handlers
         )
 
 def test_mixed_handlers_list_values():
@@ -36,5 +36,5 @@ def test_mixed_handlers_list_values():
     ]
     with pytest.raises(TraitError):
         obj = HasHandlersList(
-            handlers_list=handlers
+            handlers=handlers
         )

--- a/tests/test_traits.py
+++ b/tests/test_traits.py
@@ -1,40 +1,40 @@
 import pytest
 import logging 
 from traitlets import HasTraits, TraitError
-from jupyter_telemetry.traits import HandlersList
+from jupyter_telemetry.traits import Handlers
 
 
-class HasHandlersList(HasTraits):
-    handlers = HandlersList(
+class HasHandlers(HasTraits):
+    handlers = Handlers(
         None,
         allow_none=True
     )
 
 
-def test_good_handlers_list_value():
+def test_good_handlers_value():
     handlers = [
         logging.NullHandler(), 
         logging.NullHandler()
     ]
-    obj = HasHandlersList(
+    obj = HasHandlers(
         handlers=handlers
     )
     assert obj.handlers == handlers
 
-def test_bad_handlers_list_values():
+def test_bad_handlers_values():
     handlers = [0, 1]
     
     with pytest.raises(TraitError):
-        obj = HasHandlersList(
+        obj = HasHandlers(
             handlers=handlers
         )
 
-def test_mixed_handlers_list_values():
+def test_mixed_handlers_values():
     handlers = [
         logging.NullHandler(), 
         1
     ]
     with pytest.raises(TraitError):
-        obj = HasHandlersList(
+        obj = HasHandlers(
             handlers=handlers
         )


### PR DESCRIPTION
Here's a real solution for #12 and #14.

The pickling issue only happens when we load a list of logging handler instances from a config file. See #14 for my reason why. It has to do with a deepcopy operation we make in traitlets.

Here, I patch the `_load_config` method of the EventLog class to temporarily change `handlers` trait into a copyable function (that returns the handlers) to pass the deepcopy operation. Then, when the trait is actually set in the EventLog, it is changed back into the list of logging handlers by the trait's `validate` method. 

@yuvipanda and @jaipreet-s , what do you think of this solution?