### PR TITLE
Enable pydantic for defining+validating event schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,152 @@
 # Telemetry
 
-[![circleci](https://circleci.com/gh/jupyter/telemetry?style=shield)](https://circleci.com/gh/jupyter/telemetry)
+[![CircleCI](https://circleci.com/gh/jupyter/telemetry.svg?style=svg)](https://circleci.com/gh/jupyter/telemetry) 
 [![codecov](https://codecov.io/gh/jupyter/telemetry/branch/master/graph/badge.svg)](https://codecov.io/gh/jupyter/telemetry)
 
 Telemetry for Jupyter Applications and extensions.
 
-## Usage
+## Basic Usage
 
-### Use with PyDantic
+Telemetry provides a configurable traitlets object, `EventLog`, for structured event-logging in Python. It leverages Python's standard `logging` library for filtering, handling, and recording events. All events are validated (using [jsonschema](https://pypi.org/project/jsonschema/)) againsted registered [JSON schemas](https://json-schema.org/). 
 
+### Using the `EventLog`
+
+Let's look at a basic example of an `EventLog`.
 ```python
-
-from pydantic import BaseModel
-
-class MyEvent(BaseModel):
-
-    class Config:
-        title = 'My Event'
-        schema_extra = {
-            '$id': 'my.event',
-            'version': 1
-        }
+import logging
+from jupyter_telemetry import EventLog
 
 
+eventlog = EventLog(
+    # Use logging handlers to route where events
+    # should be record.
+    handlers=[
+        logging.FileHandler('events.log')
+    ],
+    # List schemas of events that should be recorded.
+    allowed_schemas=[
+        'uri.to.event.schema'
+    ]
+)
+```
+
+EventLog has two configurable traits:
+* `handlers`: a list of Python's `logging` handlers.
+* `allowed_schemas`: a list of event schemas to record.
+
+Event schemas must be registered with the `EventLog` for events to be recorded. An event schema looks something like:
+```json
+{
+  '$id': 'url.to.event.schema',
+  'title': 'My Event',
+  'description': 'All events must have a name property.',
+  'type': 'object',
+  'properties': {
+    'name': {
+      'title': 'Name',
+      'description': 'Name of event',
+      'type': 'string'
+    }
+  },
+  'required': ['name'],
+  'version': 1
+}
+```
+2 fields are required:
+* `$id`: a valid URI to identify the schema (and possibly fetch it from a remote address).
+* `version`: the version of the schema.
+
+The other fields are follow standard JSON schema structure.
+
+Schemas can be registered from a Python `dict` object, a file, or a URL. This example loads the above example schema from file.
+```python
+# Register the schema.
+eventlog.register_schema_file('schema.json')
+```
+
+Events are recorded using the `record_event` method. This method validates the event data and routes the JSON string to the Python `logging` handlers listed in the `EventLog`.
+```python
+# Record an example event.
+event = {'name': 'example event'}
+eventlog.record_event(
+    schema_id='url.to.event.schema',
+    version=1,
+    event=event
+)
+```
+
+### Using PyDantic to define and validate events
+
+Telemetry also works seamlessly with [pydantic](https://pydantic-docs.helpmanual.io/), a Python library useful for generating and validating schemas. Telemetry includes a convenient `Event` model (that subclasses pydantic's `BaseModel`) for defining+validating event schemas. 
+
+The following example demonstrates how to define a custom event schema using the `Event` model.
+```python
+from pydantic import Schema
+from jupyter_telemetry import Event
+
+
+class MyEvent(Event):
+    """All events must have a name property."""
+    # Required schema metadata.
+    _id = 'url.to.event.schema'
+    _title = 'My Event'
+    _version = 1
+    
+    # Define properties of event.
+    name: str = Schema(
+        ...,
+        description="Name of event"
+    )
+```
+The following class attributes are required:
+* _id: the schema ID (a valid URI)
+* _title: the title of the schema.
+* _version: the version of the schema.
+
+We can get the JSON schema of this object by calling the `.schema()` method:
+```python
+# Get schema of MyEvent
+schema = MyEvent.schema()
+
+# Print the schema as JSON.
+import json
+print(json.dumps(schema, indent=2))
+
+# {
+#   "title": "My Event",
+#   "description": "All events must have a name property.",
+#   "type": "object",
+#   "properties": {
+#     "name": {
+#       "title": "Name",
+#       "description": "Name of event",
+#       "type": "string"
+#     }
+#   },
+#   "required": [
+#     "name"
+#   ],
+#   "$id": "url.to.event.schema",
+#   "version": 1
+# }
+```
+We can register `Event` schemas using the `.register_event_model()` method. Then, we can record instances of these events using the `.record_event_model()` method:
+```python
+# Register a custom pydantic event.
+eventlog.register_event_model(MyEvent)
+
+# Create an instance of the event. 
+# pydantic handles validation.
+event = MyEvent(name='My Event')
+
+# Record the event.
+eventlog.record_event_model(event)
+```
+
+
+## Install
+
+Jupyter's Telemetry library can be installed from PyPI.
+```
+pip install jupyter_telemetry
 ```

--- a/README.md
+++ b/README.md
@@ -4,3 +4,23 @@
 [![codecov](https://codecov.io/gh/jupyter/telemetry/branch/master/graph/badge.svg)](https://codecov.io/gh/jupyter/telemetry)
 
 Telemetry for Jupyter Applications and extensions.
+
+## Usage
+
+### Use with PyDantic
+
+```python
+
+from pydantic import BaseModel
+
+class MyEvent(BaseModel):
+
+    class Config:
+        title = 'My Event'
+        schema_extra = {
+            '$id': 'my.event',
+            'version': 1
+        }
+
+
+```

--- a/jupyter_telemetry/__init__.py
+++ b/jupyter_telemetry/__init__.py
@@ -1,0 +1,1 @@
+from .event import Event

--- a/jupyter_telemetry/__init__.py
+++ b/jupyter_telemetry/__init__.py
@@ -1,1 +1,2 @@
 from .event import Event
+from .eventlog import EventLog

--- a/jupyter_telemetry/event.py
+++ b/jupyter_telemetry/event.py
@@ -2,9 +2,29 @@ from pydantic.main import MetaModel
 import pydantic
 
 class MetaEvent(MetaModel):
-    """Metaclass that maps required ar"""
-    def __new__(cls, name, base, dct):
+    """Metaclass that checks for three required class attributes:
+        1. _id: the ID of the event
+        2. _version: the version of the current schema.
+        3. _title: the name of the schema.
 
+    These attribute are mapped to pydantic.BaseModel's `Config` inner class
+    for proper schema generation+validation.
+    """
+    def __new__(cls, name, base, dct):
+        # Check that required keys are found.
+        if not all((key in dct for key in ['_id', '_title', '_version'])):
+            raise AttributeError('Required class attributes are missing from the {} class.'.format(name))
+
+        # Check that keys are the proper types.
+        if not all((
+            type(dct['_id']) in (str, type(None)),
+            type(dct['_version']) in (int, type(None)),
+            type(dct['_title']) in (str, type(None))
+            )):
+            raise TypeError('Check the class attributes types: "_id" must be a string, '
+                            '"_version" must be an integer, and "_title" must be a string.')
+
+        # Add a Config inner class to this Pydantic model.
         class Config:
            title = dct['_title']
            schema_extra = {
@@ -17,4 +37,8 @@ class MetaEvent(MetaModel):
         return super(MetaEvent, cls).__new__(cls, name, base, dct)
 
 
-Event = MetaEvent('Event', (pydantic.BaseModel,), {'_id': None, '_version': None, '_title': None})
+class Event(pydantic.BaseModel, metaclass=MetaEvent):
+    """A pydantic Model object for Jupyter Events."""
+    _id: str = None
+    _version: int = None
+    _title: str = None

--- a/jupyter_telemetry/event.py
+++ b/jupyter_telemetry/event.py
@@ -1,0 +1,20 @@
+from pydantic.main import MetaModel
+import pydantic
+
+class MetaEvent(MetaModel):
+    """Metaclass that maps required ar"""
+    def __new__(cls, name, base, dct):
+
+        class Config:
+           title = dct['_title']
+           schema_extra = {
+                '$id': dct['_id'],
+                'version': dct['_version']
+           }
+
+        dct['Config'] = Config
+
+        return super(MetaEvent, cls).__new__(cls, name, base, dct)
+
+
+Event = MetaEvent('Event', (pydantic.BaseModel,), {'_id': None, '_version': None, '_title': None})

--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -126,15 +126,14 @@ class EventLog(Configurable):
 
         self.schemas[(schema['$id'], schema['version'])] = schema
 
-    def register_event_model(self, events):
+    def register_event_model(self, event):
         """Register schemas from pydantic Model objects.
 
         events : list of pydantic Model objects.
         """
-        for event in events:
-            if not issubclass(event, pydantic.BaseModel):
-                raise TypeError("event must be a subclass of pydantic.BaseModel.")
-            self.register_schema(event.schema())
+        if not issubclass(event, pydantic.BaseModel):
+            raise TypeError("event must be a subclass of pydantic.BaseModel.")
+        self.register_schema(event.schema())
 
     def record_event_model(self, event):
         """Record given event with schema has occurred.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+jsonschema
+pythonjsonlogger
+traitlets
+ruamel.yaml
+pydantic

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,97 @@
+import pytest
+
+from enum import Enum
+from pydantic import Schema, ValidationError
+
+from jupyter_telemetry.event import Event
+
+
+@pytest.fixture
+def mock_event():
+    # Define a property for MockEvent that's a list.
+    class Actions(str, Enum):
+        act1 = 'act1'
+        act2 = 'act2'
+
+    # Create MockEvent
+    class MockEvent(Event):
+        _id = 'mock.id'
+        _title = 'my mock event'
+        _version = 1
+
+        prop1: int = Schema(
+            ...,
+            title='prop1',
+            description="property #1"
+        )
+        prop2: Actions = Schema(
+            ...,
+            title='list of actions',
+            description="property #2 with list of actions"
+        )
+
+    return MockEvent
+
+def test_bad_attr_in_event():
+    with pytest.raises(TypeError):
+        # Define an event object with the wrong type for "title"
+        class MockBadEvent(Event):
+            _title = 2
+            _version = 1
+            _id = 'test'
+
+def test_missing_attr_in_event():
+    with pytest.raises(AttributeError):
+        # Define an event object with missing attr.
+        class MockBadEvent(Event):
+            # Missing _version
+            _id = 'test'
+            _title = 'test'
+
+
+def test_class_creation():
+    # Create a working class
+    class MockEvent(Event):
+        _id = 'test'
+        _title = 'test'
+        _version = 1
+
+    assert hasattr(MockEvent, 'Config')
+    assert hasattr(MockEvent.Config, 'schema_extra')
+    assert all((key in MockEvent.Config.schema_extra for key in ['version', '$id']))
+
+
+def test_schema_generation():
+    # Create a working class
+    class MockEvent(Event):
+        _id = 'test'
+        _title = 'test'
+        _version = 1
+
+    schema = MockEvent.schema()
+    assert all((key in schema for key in ['title', 'type', '$id', 'version']))
+
+
+def test_schema_validation(mock_event):
+    # Create an instance of mock event.
+    # Nothing should happen is validation
+    # is successful.
+    try:
+        event = mock_event(
+            prop1=1,
+            prop2='act1'
+        )
+    except:
+        pytest.fail("Unexpected error when trying to validate MockEvent instance.")
+
+    data = event.json()
+    
+
+def test_schema_validation_failure(mock_event):
+    # Setting prop1 to a string raises Validation error.
+    with pytest.raises(ValidationError):
+        event = mock_event(
+            prop1='this is not an int',
+            prop2='act1'
+        )
+


### PR DESCRIPTION
This was inspired by conservations I've had with @tonyfast.

This PR introduces [pydantic](https://pydantic-docs.helpmanual.io/#) to jupyter/telemetry.

We can use pydantic to define structured event data models (in Python), auto-generate the JSON schema, and validate new event instances. 

## Why?
There are a few advantages to using pydantic:
* Event data emitted from Python are written in Python (useful for writing tests). 
* We can autogenerate schemas from Python (useful for sphinx-docs).
* Events are importable, rather than *always* being scraped from source.
* Validation is fast.
* Plug into a rich Python ecosystem, maybe mkaing telemetry more useful beyond Jupyter.

## What?
This doesn't change how the current EventLog works; rather I made two major additions:
* Add an `Event` class—a subclass of pydantic's `BaseModel`—for structured event data. This is more of a syntax convenience than a necessity. `BaseModel` can be used, but it requires users to define extra configuration.
* Add methods for registering and recording `Event`s with the `EventLog` class. 

## Basic Example 

To demonstrate the utility of the `Event` object, here's an example of creating a custom event (subclassing the `Event` class):
```python
from pydantic import Schema
from jupyter_telemetry import Event

class MyEvent(Event):
    """All events must have a name property."""
    # Required schema metadata.
    _id = 'url.to.event.schema'
    _title = 'My Event'
    _version = 1
    
    # Define properties of event.
    name: str = Schema(
        ...,
        description="Name of event"
    )
```

I can generate the JSON schema from this object by calling `.schema()`:
```python
# Get schema of MyEvent
schema = MyEvent.schema()

# Print the schema as JSON.
import json
print(json.dumps(schema, indent=2))

# {
#   "title": "My Event",
#   "description": "All events must have a name property.",
#   "type": "object",
#   "properties": {
#     "name": {
#       "title": "Name",
#       "description": "Name of event",
#       "type": "string"
#     }
#   },
#   "required": [
#     "name"
#   ],
#   "$id": "url.to.event.schema",
#   "version": 1
# }
```

I can register this object with the `EventLog`:
```python
eventlog.register_event_model(MyEvent)
```

Then, I can create and record an event:
```python
# Create an instance of the event. 
# pydantic handles validation.
event = MyEvent(name='My Event')

# Record the event.
eventlog.record_event_model(event)
```

