### PR TITLE
Add __metadata_version__ to event capsule

### DIFF
--- a/jupyter_telemetry/__init__.py
+++ b/jupyter_telemetry/__init__.py
@@ -1,0 +1,3 @@
+# Increment this version when the metadata included with each event
+# changes.A
+TELEMETRY_METADATA_VERSION = 1

--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -139,10 +139,14 @@ class EventLog(Configurable):
         schema = self.schemas[(schema_name, version)]
         jsonschema.validate(event, schema)
 
+        # Incremented every time we change the capsule itself
+        telemetry_version = 1
+
         capsule = {
             '__timestamp__': datetime.utcnow().isoformat() + 'Z',
             '__schema__': schema_name,
-            '__version__': version
+            '__schema_version__': version,
+            '__telemetry_version__': telemetry_version
         }
         capsule.update(event)
         self.log.info(capsule)

--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -12,6 +12,7 @@ from traitlets import List
 from traitlets.config import Configurable, Config
 
 from .traits import Handlers
+from . import TELEMETRY_METADATA_VERSION
 
 yaml = YAML(typ='safe')
 
@@ -139,14 +140,11 @@ class EventLog(Configurable):
         schema = self.schemas[(schema_name, version)]
         jsonschema.validate(event, schema)
 
-        # Incremented every time we change the capsule itself
-        telemetry_version = 1
-
         capsule = {
             '__timestamp__': datetime.utcnow().isoformat() + 'Z',
             '__schema__': schema_name,
             '__schema_version__': version,
-            '__telemetry_version__': telemetry_version
+            '__metadata_version__': TELEMETRY_METADATA_VERSION
         }
         capsule.update(event)
         self.log.info(capsule)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='jupyter_telemetry',
-    version='0.0.2',
+    version='0.0.3',
     description='Jupyter telemetry library',
     packages=find_packages(),
     author          = 'Jupyter Development Team',

--- a/tests/test_register_schema.py
+++ b/tests/test_register_schema.py
@@ -93,7 +93,7 @@ def test_record_event():
     assert event_capsule == {
         '__schema__': 'test/test',
         '__schema_version__': 1,
-        '__telemetry_version__': 1,
+        '__metadata_version__': 1,
         'something': 'blah'
     }
 

--- a/tests/test_register_schema.py
+++ b/tests/test_register_schema.py
@@ -92,7 +92,8 @@ def test_record_event():
     del event_capsule['__timestamp__']
     assert event_capsule == {
         '__schema__': 'test/test',
-        '__version__': 1,
+        '__schema_version__': 1,
+        '__telemetry_version__': 1,
         'something': 'blah'
     }
 


### PR DESCRIPTION
We might add more fields or change the meaning of fields in
the capsule itself. This lets us do so in a way that is backwards
compatible and explicit. Analysts can use this field to determine
exactly what data they are working with.

We rename __version__ to __schema_version__ to distinguish
this now. This is a backwards incompatible change, but it's
early enough to be ok