### PR TITLE
Sphinx extension to autogenerate schemas docs from schemas directory

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ Jupyter Telemetry
 
 Telemetry provides a configurable traitlets object, EventLog, for structured event-logging in Python. It leverages Python's standard logging library for filtering, handling, and recording events. All events are validated (using jsonschema) against registered JSON schemas.
 
-If you're looking for telemetry in Jupyter frontend applications (like JupyterLab), checkout the work happening in jupyterlab-telemetry_! 
+If you're looking for telemetry in Jupyter frontend applications (like JupyterLab), checkout the work happening in jupyterlab-telemetry_!
 
 .. _jupyterlab-telemetry: https://github.com/jupyterlab/jupyterlab-telemetry
 
@@ -98,8 +98,8 @@ Schemas can be registered from a Python dict object, a file, or a URL. This exam
    :maxdepth: 2
    :caption: Table of Contents:
 
-   pages/schemas.rst
-
+   pages/writing-a-schema
+   pages/sphinxext
 
 Indices and tables
 ------------------

--- a/docs/pages/sphinxext.rst
+++ b/docs/pages/sphinxext.rst
@@ -1,0 +1,24 @@
+Schema Documentation in Sphinx
+==============================
+
+Jupyter Telemetry provides a Sphinx Extension to automatically generate documentation
+from a directory of Event-logging schemas.
+
+To activate this extension, add ``jupyter_telemetry.sphinxext`` to your ``conf.py`` file
+and set the following configuration values:
+
+.. code-block:: python
+
+    # config.py file.
+
+    extensions = [
+        'jupyter_telemetry.sphinxext',
+        ...
+    ]
+
+    # Jupyter telemetry configuration values.
+    jupyter_telemetry_schema_source = "path/to/schemas/source/directory"   # Path is relative to conf.py
+    jupyter_telemetry_schema_output = "path/to/output/directory"           # Path is relative to conf.py
+    jupyter_telemetry_index_title = "Example Event Schemas"                # Title of the index page that lists all found schemas.
+
+

--- a/docs/pages/writing-a-schema.rst
+++ b/docs/pages/writing-a-schema.rst
@@ -2,7 +2,7 @@ Writing a Schema
 ================
 
 
-Schemas should follow valid `JSON schema`_. These schemas can be written in valid YAML or JSON. 
+Schemas should follow valid `JSON schema`_. These schemas can be written in valid YAML or JSON.
 
 At a minimum, valid schemas should have the following keys:
 

--- a/jupyter_telemetry/sphinxext.py
+++ b/jupyter_telemetry/sphinxext.py
@@ -10,6 +10,7 @@ JsonSchema = __import__('sphinx-jsonschema').JsonSchema
 
 yaml = YAML(typ='safe')
 
+
 # Use the JsonSchema directive from sphinx-jsonschema,
 # But replace the directive name so that we don't
 # require this users to list both the 'jupyter_telemetry_schema'

--- a/jupyter_telemetry/sphinxext.py
+++ b/jupyter_telemetry/sphinxext.py
@@ -1,0 +1,92 @@
+import os
+import json
+import pathlib
+import textwrap
+from ruamel.yaml import YAML
+# Cannot import sphinx-jsonschema using import statement
+# because the name contains a hyphen.
+JsonSchema = __import__('sphinx-jsonschema').JsonSchema
+
+
+yaml = YAML(typ='safe')
+
+# Use the JsonSchema directive from sphinx-jsonschema,
+# But replace the directive name so that we don't
+# require this users to list both the 'jupyter_telemetry_schema'
+# and 'sphinx-jsonschema' extensions in their conf.py.
+class JupyterTelemetrySchema(JsonSchema):
+
+    def __init__(self, directive, *args, **kwargs):
+        # There is an `assert` statement in JsonSchema that
+        # requires the directive to == 'jsonschema'.
+        # Here we substitute this directive in, even though
+        # the directive is actually 'jupyter_telemetry_schema'.
+        super(JupyterTelemetrySchema, self).__init__(
+            'jsonschema',
+            *args, **kwargs
+        )
+
+
+def create_event_schema_docs(app, config):
+
+    src = config.jupyter_telemetry_schema_source
+    out = config.jupyter_telemetry_schema_output
+    title = config.jupyter_telemetry_index_title
+
+    # If src or out path is not given, don't do anything.
+    if src is None:
+        return
+
+    if out is None:
+        return
+
+    src_base_path = pathlib.Path(src)
+    out_base_path = pathlib.Path(out)
+
+    # Write schema RST files.
+    schema_paths = []
+    for (base, _, files) in os.walk(src):
+        for f in files:
+            src_path = pathlib.Path(base).joinpath(f)
+            # Verify that the file is a JSON or YAML file, otherwise ignore.
+            if src_path.suffix in ['.json', 'yaml']:
+                rel_path = src_path.relative_to(src_base_path)
+                out_path = out_base_path.joinpath(rel_path)
+                out_path = out_path.with_suffix('.rst')
+
+                data = yaml.load(src_path.read_text())
+                json_data = json.dumps(data, indent=4)
+                doc_text = ".. jupyter_telemetry_schema::\n\n" + textwrap.indent(json_data, '\t')
+
+                # Make the directory if it doesn't exist.
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_text(doc_text)
+
+                index_path = rel_path.with_suffix('')
+                schema_paths.append(str(index_path))
+
+    # Write the index.
+    index = out_base_path.joinpath('index.rst')
+    schema_list = textwrap.indent('\n'.join(schema_paths), '\t')
+    index_text = (
+        "{}".format(title),
+        "{}\n".format("="*len(title)),
+        ".. toctree::\n",
+        "{}".format(schema_list)
+    )
+    index.write_text('\n'.join(index_text))
+
+
+def setup(app):
+    app.add_config_value("jupyter_telemetry_schema_source", None, "html")
+    app.add_config_value("jupyter_telemetry_schema_output", None, "html")
+    app.add_config_value("jupyter_telemetry_index_title", "Event Schemas", "html")
+    app.add_directive('jupyter_telemetry_schema', JupyterTelemetrySchema)
+
+    # Build event schema source files before reading+building docs.
+    app.connect("config-inited", create_event_schema_docs)
+    return {
+        'version': '0.1',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+jsonschema
+python-json-logger
+traitlets
+ruamel.yaml
+sphinx-jsonschema

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'jsonschema',
         'python-json-logger',
         'traitlets',
-        'ruamel.yaml'
+        'ruamel.yaml',
+        'sphinx-jsonschema'
     ],
 )


### PR DESCRIPTION
This allows users to automatically generate sphinx documentation for a directory Jupyter Telemetry event schemas. 

User needs to add `jupyter_telemetry.sphinxext` the Sphinx `config.py` extensions list and set the following config values:
```python
    extensions = [
        'jupyter_telemetry.sphinxext',
        ...
    ]

    jupyter_telemetry_schema_source = "path/to/schemas/source/directory"   # Path is relative to conf.py
    jupyter_telemetry_schema_output = "path/to/output/directory"           # Path is relative to conf.py
    jupyter_telemetry_index_title = "Example Event Schemas"                # Title of the index page that lists all found schemas.
```

This will create:
1. A directory of `.rst` files for each schema found in the source directory.
    * These files contain a new Sphinx directive, `jupyter_telemetry_schema`, and the JSON representation of the schema. 
    * The output directory maintains the same directory tree as the source directory, picking up all nested files/structures. 
2. An `index.rst` in the base of the output directory that lists all the schemas in a TOC. 

@minrk, I know you're interested in something like this. 