### PR TITLE
 ruamel_yaml conda compatibility

### DIFF
--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -7,7 +7,10 @@ from datetime import datetime
 
 import jsonschema
 from pythonjsonlogger import jsonlogger
-from ruamel.yaml import YAML
+try:
+    from ruamel.yaml import YAML
+except ImportError:
+    from ruamel_yaml import YAML
 from traitlets import List
 from traitlets.config import Configurable, Config
 


### PR DESCRIPTION
In case of `importError` or `ModuleNotFoundError`. Solved issue [Solved issue https://github.com/jupyterhub/jupyterhub/issues/3145]( https://github.com/jupyterhub/jupyterhub/issues/3145)