### PR TITLE
raise informative error when ruamel.yaml is missing due to ruamel_yaml

### DIFF
--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -7,7 +7,23 @@ from datetime import datetime
 
 import jsonschema
 from pythonjsonlogger import jsonlogger
-from ruamel.yaml import YAML
+try:
+    from ruamel.yaml import YAML
+except ImportError as e:
+    # check for known conda bug that prevents
+    # pip from installing ruamel.yaml dependency
+    try:
+        import ruamel_yaml  # noqa
+    except ImportError:
+        # nope, regular import error; raise original
+        raise e
+    else:
+        # have conda fork ruamel_yaml, but not ruamel.yaml.
+        # this is a bug in the ruamel_yaml conda package
+        # mistakenly identifying itself as ruamel.yaml to pip.
+        # conda install the 'real' ruamel.yaml to fix
+        raise ImportError("Missing dependency ruamel.yaml. Try: `conda install ruamel.yaml`")
+
 from traitlets import List
 from traitlets.config import Configurable, Config
 


### PR DESCRIPTION
conda ruamel_yaml fork can prevent pip installing ruamel.yaml dependency, so raise an informative error about how to fix this when it (probably) occurs.

alternative to #48 which tries to use the forked package instead.

Since there's a clear, easy workaround for conda and the bug is in the conda ruamel_yaml package (hopefully fixed in the future by https://github.com/conda-forge/ruamel_yaml-feedstock/pull/68), I think this informative error which tells you exactly how to fix the problem is preferable to using the different package, which can come with its own issues over time.

closes #48