### PR TITLE
Cleaner syntax for linking event schemas to event methods

### DIFF
--- a/jupyter_telemetry/__init__.py
+++ b/jupyter_telemetry/__init__.py
@@ -4,3 +4,4 @@ TELEMETRY_METADATA_VERSION = 1
 
 
 from .eventlog import EventLog  # noqa
+from .utils import event_schema

--- a/jupyter_telemetry/utils.py
+++ b/jupyter_telemetry/utils.py
@@ -1,0 +1,21 @@
+
+class JupyterTelemetryException(Exception):
+    """Exceptions for Jupyter Telemetry"""
+
+
+def event_schema(name, version, schema=None):
+    """Decorator for wrapping methods with information about
+    the type of event data emitted by the method.
+    """
+    def method_wrapper(method):
+        # Needs to wrap a method, so adding one more layer
+        # of depth to handle self.
+        def jupyter_telemetry_event_wrapper(self, *args, **kwargs):
+            self.eventlog._set_incoming_event(name, version)
+            output = method(self, *args, **kwargs)
+            # Flush the current event.
+            self._clear_incoming_event()
+            return output
+        return jupyter_telemetry_event_wrapper
+
+    return method_wrapper


### PR DESCRIPTION
This is a syntax sugar. It adds a new decorator, `event_schema`, that can be called above a method to describe what telemetry data is collected by that method. This cleanly separates the telemetry definition logic from the application logic. 

Before:
```python
    def method_to_record(self):
        ...
        self.eventlog.record_event(
            schema_name="my_event",
            version=1,
            event=...
        )
```
After this PR:
```python
    @event_schema(
        schema_name="my_event",
        version=1
    )
    def method_to_record(self):
        ...
        self.eventlog.record_event(event=...)
```

Normally, I don't think this kind of syntax sugar is necessary. In this case, though, it makes the code more readable. You can quickly scan through multiple methods to see which methods emit telemetry data and what data each method emits. No need to sift through the source code of the methods themselves.

This is fully backwards compatible. It's merely for readability.