### PR TITLE
Return event after emitting

### DIFF
--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -245,3 +245,4 @@ class EventLog(Configurable):
                 capsule[property_name] = None
 
         self.log.info(capsule)
+        return capsule

--- a/jupyter_telemetry/eventlog.py
+++ b/jupyter_telemetry/eventlog.py
@@ -195,6 +195,22 @@ class EventLog(Configurable):
     def record_event(self, schema_name, version, event, timestamp_override=None):
         """
         Record given event with schema has occurred.
+
+        Parameters
+        ----------
+        schema_name: str
+            Name of the schema
+        version: str
+            The schema version
+        event: dict
+            The event to record
+        timestamp_override: datetime, optional
+            Optionally override the event timestamp. By default it is set to the current timestamp.
+
+        Returns
+        -------
+        dict
+            The recorded event data
         """
         if not (self.handlers and schema_name in self.allowed_schemas):
             # if handler isn't set up or schema is not explicitly whitelisted,


### PR DESCRIPTION
I kinda like the idea of `record_event` returning the event at the end. Would make things like testing a lot more convenient. Only downside is that

```python
event = eventlog.record_event(...)
```

would make it a bit less clear that `record_event` is called for side effect, but most of the time if users have no use for the event they would just call `eventlog.record_event(...)` without assigning the returned value anyway.