### PR TITLE
Use fastjsonschema for json schema validation

### DIFF
--- a/jupyter_telemetry/eventschema.py
+++ b/jupyter_telemetry/eventschema.py
@@ -1,0 +1,67 @@
+import jsonschema
+import fastjsonschema
+
+
+class EventSchemaValidator:
+    def __init__(self, schema):
+        pass
+
+    def validate(self, instance):
+        pass
+
+
+class EventSchema:
+    def __init__(self, schema, validator_cls: EventSchemaValidator):
+        self.schema = schema
+        self._validator = validator_cls(schema)
+
+    def validate(self, instance):
+        self._validator.validate(instance)
+
+
+class JSONSchemaError(Exception):
+    pass
+
+
+class JSONValidationError(Exception):
+    pass
+
+
+class JSONSchemaValidator(EventSchemaValidator):
+    def __init__(self, schema):
+        ivalidator = jsonschema.validators.validator_for(schema)
+
+        try:
+            ivalidator.check_schema(schema)
+        except jsonschema.SchemaError as e:
+            raise JSONSchemaError(e.message) from e
+
+        self._validator = ivalidator(schema)
+
+    def validate(self, instance):
+        try:
+            self._validator.validate(instance)
+        except jsonschema.ValidationError as e:
+            raise JSONValidationError(e.message) from e
+
+
+class FastJSONSchemaValidator(EventSchemaValidator):
+    def __init__(self, schema):
+        try:
+            self._validate = fastjsonschema.compile(schema)
+        except fastjsonschema.JsonSchemaDefinitionException as e:
+            raise JSONSchemaError(e.message) from e
+        except Exception as e:
+            raise JSONSchemaError from e
+
+    def validate(self, instance):
+        try:
+            self._validate(instance)
+        except fastjsonschema.JsonSchemaException as e:
+            raise JSONValidationError(e.message) from e
+
+
+JSON_SCHEMA_VALIDATORS = {
+    'jsonschema': JSONSchemaValidator,
+    'fastjsonschema': FastJSONSchemaValidator
+}

--- a/jupyter_telemetry/traits.py
+++ b/jupyter_telemetry/traits.py
@@ -62,8 +62,8 @@ class SchemaOptions(TraitType):
                     raise TraitError(
                         "The schema option, {schema_name}, includes "
                         "unknown key(s): {unknown_keys}".format(
-                           schema_name=schema_name,
-                           unknown_keys=",".join(unknown_keys)
+                            schema_name=schema_name,
+                            unknown_keys=",".join(unknown_keys)
                         )
                     )
             validated_val = val

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'jsonschema',
         'python-json-logger',
         'traitlets',
-        'ruamel.yaml'
+        'ruamel.yaml',
+        'fastjsonschema'
     ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+from jupyter_telemetry.eventschema import JSON_SCHEMA_VALIDATORS
+
+
+def pytest_generate_tests(metafunc):
+    if "json_validator" in metafunc.fixturenames:
+        metafunc.parametrize("json_validator", JSON_SCHEMA_VALIDATORS.keys())

--- a/tests/test_allowed_schemas.py
+++ b/tests/test_allowed_schemas.py
@@ -12,9 +12,10 @@ import pytest
 SCHEMA_ID = "test.event"
 VERSION = 1
 
+
 @pytest.fixture
 def schema():
-    return  {
+    return {
         '$id': SCHEMA_ID,
         'title': 'Test Event',
         'version': VERSION,
@@ -40,7 +41,7 @@ def schema():
     }
 
 
-def test_raised_exception_for_nonlist_categories():
+def test_raised_exception_for_nonlist_categories(json_validator):
     # Bad schema in yaml form.
     yaml_schema = _("""\
     $id: test.schema
@@ -63,6 +64,7 @@ def test_raised_exception_for_nonlist_categories():
                 "allowed_categories": ["user-identifier"]
             }
         },
+        json_validator=json_validator
     )
 
     # This schema does not have categories as a list.
@@ -72,7 +74,7 @@ def test_raised_exception_for_nonlist_categories():
     assert 'must be a list.' in str(err.value)
 
 
-def test_missing_categories_label():
+def test_missing_categories_label(json_validator):
     # Bad schema in yaml form.
     yaml_schema = _("""\
     $id: test.schema
@@ -93,7 +95,8 @@ def test_missing_categories_label():
             SCHEMA_ID: {
                 "allowed_categories": ["random-category"]
             }
-        }
+        },
+        json_validator=json_validator
     )
 
     # This schema does not have categories as a list.
@@ -103,12 +106,12 @@ def test_missing_categories_label():
     assert 'All properties must have a "categories"' in str(err.value)
 
 
-
 EVENT_DATA = {
     'nothing-exciting': 'hello, world',
     'id': 'test id',
     'email': 'test@testemail.com',
 }
+
 
 @pytest.mark.parametrize(
     'allowed_schemas,expected_output',
@@ -197,7 +200,7 @@ EVENT_DATA = {
         ),
     ]
 )
-def test_allowed_schemas(schema, allowed_schemas, expected_output):
+def test_allowed_schemas(json_validator, schema, allowed_schemas, expected_output):
     sink = io.StringIO()
 
     # Create a handler that captures+records events with allowed tags.
@@ -205,7 +208,8 @@ def test_allowed_schemas(schema, allowed_schemas, expected_output):
 
     e = EventLog(
         handlers=[handler],
-        allowed_schemas=allowed_schemas
+        allowed_schemas=allowed_schemas,
+        json_validator=json_validator
     )
     e.register_schema(schema)
 
@@ -222,4 +226,3 @@ def test_allowed_schemas(schema, allowed_schemas, expected_output):
 
     # Verify that *exactly* the right properties are recorded.
     assert expected_output == event_data
-

--- a/tests/test_register_schema.py
+++ b/tests/test_register_schema.py
@@ -24,13 +24,13 @@ def test_register_invalid_schema(json_validator):
         })
 
 
-def test_missing_required_properties():
+def test_missing_required_properties(json_validator):
     """
     id and $version are required properties in our schemas.
 
     They aren't required by JSON Schema itself
     """
-    el = EventLog()
+    el = EventLog(json_validator=json_validator)
     with pytest.raises(ValueError):
         el.register_schema({
             'properties': {}
@@ -43,13 +43,13 @@ def test_missing_required_properties():
         })
 
 
-def test_reserved_properties():
+def test_reserved_properties(json_validator):
     """
     User schemas can't have properties starting with __
 
     These are reserved
     """
-    el = EventLog()
+    el = EventLog(json_validator=json_validator)
     with pytest.raises(ValueError):
         el.register_schema({
             '$id': 'test/test',
@@ -63,7 +63,7 @@ def test_reserved_properties():
         })
 
 
-def test_timestamp_override():
+def test_timestamp_override(json_validator):
     """
     Simple test for overriding timestamp
     """
@@ -80,7 +80,7 @@ def test_timestamp_override():
 
     output = io.StringIO()
     handler = logging.StreamHandler(output)
-    el = EventLog(handlers=[handler])
+    el = EventLog(handlers=[handler], json_validator=json_validator)
     el.register_schema(schema)
     el.allowed_schemas = ['test/test']
 
@@ -95,7 +95,7 @@ def test_timestamp_override():
     assert event_capsule['__timestamp__'] == timestamp_override.isoformat() + 'Z'
 
 
-def test_record_event():
+def test_record_event(json_validator):
     """
     Simple test for emitting valid events
     """
@@ -112,7 +112,7 @@ def test_record_event():
 
     output = io.StringIO()
     handler = logging.StreamHandler(output)
-    el = EventLog(handlers=[handler])
+    el = EventLog(handlers=[handler], json_validator=json_validator)
     el.register_schema(schema)
     el.allowed_schemas = ['test/test']
 
@@ -134,7 +134,7 @@ def test_record_event():
     }
 
 
-def test_register_schema_file(tmp_path):
+def test_register_schema_file(tmp_path, json_validator):
     """
     Register schema from a file
     """
@@ -149,7 +149,7 @@ def test_register_schema_file(tmp_path):
         },
     }
 
-    el = EventLog()
+    el = EventLog(json_validator=json_validator)
 
     yaml = YAML(typ='safe')
 
@@ -160,7 +160,7 @@ def test_register_schema_file(tmp_path):
     assert schema in (s.schema for s in el.schemas.values())
 
 
-def test_register_schema_file_object(tmp_path):
+def test_register_schema_file_object(tmp_path, json_validator):
     """
     Register schema from a file
     """
@@ -175,7 +175,7 @@ def test_register_schema_file_object(tmp_path):
         },
     }
 
-    el = EventLog()
+    el = EventLog(json_validator=json_validator)
 
     yaml = YAML(typ='safe')
 
@@ -187,7 +187,7 @@ def test_register_schema_file_object(tmp_path):
     assert schema in (s.schema for s in el.schemas.values())
 
 
-def test_allowed_schemas():
+def test_allowed_schemas(json_validator):
     """
     Events should be emitted only if their schemas are allowed
     """
@@ -204,7 +204,7 @@ def test_allowed_schemas():
 
     output = io.StringIO()
     handler = logging.StreamHandler(output)
-    el = EventLog(handlers=[handler])
+    el = EventLog(handlers=[handler], json_validator=json_validator)
     # Just register schema, but do not mark it as allowed
     el.register_schema(schema)
 
@@ -216,7 +216,7 @@ def test_allowed_schemas():
     assert output.getvalue() == ''
 
 
-def test_record_event_badschema():
+def test_record_event_badschema(json_validator):
     """
     Fail fast when an event doesn't conform to its schema
     """
@@ -246,7 +246,7 @@ def test_record_event_badschema():
         })
 
 
-def test_unique_logger_instances():
+def test_unique_logger_instances(json_validator):
     schema0 = {
         '$id': 'test/test0',
         'version': 1,
@@ -274,7 +274,7 @@ def test_unique_logger_instances():
     handler0 = logging.StreamHandler(output0)
     handler1 = logging.StreamHandler(output1)
 
-    el0 = EventLog(handlers=[handler0])
+    el0 = EventLog(handlers=[handler0], json_validator=json_validator)
     el0.register_schema(schema0)
     el0.allowed_schemas = ['test/test0']
 
@@ -316,7 +316,7 @@ def test_unique_logger_instances():
     }
 
 
-def test_register_duplicate_schemas():
+def test_register_duplicate_schemas(json_validator):
     schema0 = {
         '$id': 'test/test',
         'version': 1,
@@ -339,7 +339,7 @@ def test_register_duplicate_schemas():
         },
     }
 
-    el = EventLog()
+    el = EventLog(json_validator=json_validator)
     el.register_schema(schema0)
     with pytest.raises(ValueError):
         el.register_schema(schema1)


### PR DESCRIPTION
Add default option to use [fastjsonschema](https://horejsek.github.io/python-fastjsonschema/) to validate events. This should speed up validation. Will add benchmarks soon.

Inspired by
https://github.com/jupyter/nbformat/blob/dd4725fb41515c69bc76e1c7f32f3ede0075725f/nbformat/json_compat.py