### PR TITLE
add readthedocs yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+   os: ubuntu-20.04
+   tools:
+      python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+      - method: pip
+        path: .
+        extra_requirements:
+           - docs


### PR DESCRIPTION
The new documentation pages aren't building because readthedocs needs to know how to install the documentation dependencies. This configuration file should address the issue. 